### PR TITLE
Events Support

### DIFF
--- a/FAtiMA-DST/modinfo.lua
+++ b/FAtiMA-DST/modinfo.lua
@@ -35,25 +35,38 @@ server_filter_tags = {"ai"}
 
  configuration_options =
  {
---     {
---         name = "EventKilled",
---         label = "Listen to the 'killed' event",
---         options = 
---         {
---             {description = "1", data = 1},
---             {description = "5", data = 5},
---             {description = "25", data = 25}
---         },
---         default = 5,
---     },
      {
-         name = "EventKilled",
+         name = "Killed",
          label = "Listen to the 'killed' event",
          options = 
          {
-             {description = "True", data = true},
-             {description = "False", data = false}
+             {description = "False", data = false},
+			 {description = "True", data = true}
+             
          },
-         default = true,
+         default = false,
      }
+--	 ,
+--	 {
+--         name = "onattackother",
+--         label = "Listen to the 'onattackother' event",
+--         options = 
+--         {
+--             {description = "False", data = false},
+--             {description = "True", data = true}
+
+--         },
+--         default = false,
+--     },
+--	 {
+--         name = "onmissother",
+--         label = "Listen to the 'onmissother' event",
+--         options = 
+--         {
+--             {description = "False", data = false},
+--             {description = "True", data = true}
+--         },
+--         default = false,
+--     }
+	 
  }

--- a/FAtiMA-DST/modinfo.lua
+++ b/FAtiMA-DST/modinfo.lua
@@ -37,7 +37,51 @@ server_filter_tags = {"ai"}
  {
      {
          name = "Killed",
-         label = "Listen to the 'killed' event",
+         label = "'killed'",
+         options = 
+         {
+             {description = "False", data = false},
+			 {description = "True", data = true}
+             
+         },
+         default = false,
+     },
+	 {
+         name = "Death",
+         label = "'death'",
+         options = 
+         {
+             {description = "False", data = false},
+			 {description = "True", data = true}
+             
+         },
+         default = false,
+     },
+	 {
+         name = "Attacked",
+         label = "'attacked'",
+         options = 
+         {
+             {description = "False", data = false},
+			 {description = "True", data = true}
+             
+         },
+         default = false,
+     },
+	 {
+         name = "MissOther",
+         label = "'onmissother'",
+         options = 
+         {
+             {description = "False", data = false},
+			 {description = "True", data = true}
+             
+         },
+         default = false,
+     },
+	 {
+         name = "HitOther",
+         label = "'onhitother'",
          options = 
          {
              {description = "False", data = false},
@@ -46,27 +90,4 @@ server_filter_tags = {"ai"}
          },
          default = false,
      }
---	 ,
---	 {
---         name = "onattackother",
---         label = "Listen to the 'onattackother' event",
---         options = 
---         {
---             {description = "False", data = false},
---             {description = "True", data = true}
-
---         },
---         default = false,
---     },
---	 {
---         name = "onmissother",
---         label = "Listen to the 'onmissother' event",
---         options = 
---         {
---             {description = "False", data = false},
---             {description = "True", data = true}
---         },
---         default = false,
---     }
-	 
- }
+}

--- a/FAtiMA-DST/scripts/brains/walterbrain.lua
+++ b/FAtiMA-DST/scripts/brains/walterbrain.lua
@@ -133,6 +133,12 @@ local function Decide(inst, brain)
         "GET")
 end
 
+local function Event(name, value, brain)
+	print(name, value)
+	for k, v in pairs(value) do
+		print(k, v)
+	end
+end
 local function OnActionEndEvent(name, value, brain)
 	local d = {}
 	d.Type= "Action-End"
@@ -229,12 +235,33 @@ function WalterBrain:OnStart()
 
 	-- Listen to phases of the day changes
 	-- This is actualy a perception, but it is perferable to check for changes instead of constantly checking its value.
-	self.inst:ListenForEvent("phasechanged", function(inst, data) OnPropertyChangedEvent("Day(Phase)", data, self) end, TheWorld)
-    
+	self.inst:ListenForEvent("phasechanged", function(inst, data) OnPropertyChangedEvent("Day(Phase)", data, self) end)
+    self.inst:ListenForEvent("enterdark", function(inst, data) OnPropertyChangedEvent("Light(Walter)", "dark", self) end)
+	self.inst:ListenForEvent("enterlight", function(inst, data) OnPropertyChangedEvent("Light(Walter)", "light", self) end)
+
 	-- Events configurable in the Mod Config
 	if GetModConfigData("Killed", KnownModIndex:GetModActualName("FAtiMA-DST")) then self.inst:ListenForEvent("killed", function(inst, data) OnActionEndEvent("Killed", data.victim.GUID, self) end) end
-	-- self.inst:ListenForEvent("onattackother", function(inst, data) OnActionEndEvent("AttackOther", data, self) end)
-	-- "onattackother", "onmissother", "onhitother", "attacked", "weathertick", "seasontick", "precipitationchanged", "death", "playeractivated", "playerdeactivated", "enterdark", "enterlight", "nightvision", "healthdelta", "ms_playerjoined", "ms_playerleft", "playerdied", "ms_advanceseason", "onignite", "buildstructure", "builditem"
+	if GetModConfigData("Attacked", KnownModIndex:GetModActualName("FAtiMA-DST")) then self.inst:ListenForEvent("attacked", function(inst, data) OnActionEndEvent("Attacked", data.attacker.GUID, self) end) end
+	if GetModConfigData("Death", KnownModIndex:GetModActualName("FAtiMA-DST")) then self.inst:ListenForEvent("death", function(inst, data) OnActionEndEvent("Death", data.afflicter.GUID, self) end) end
+	if GetModConfigData("MissOther", KnownModIndex:GetModActualName("FAtiMA-DST")) then self.inst:ListenForEvent("onmissother", function(inst, data) OnActionEndEvent("MissOther", data.target.GUID, self) end) end
+	if GetModConfigData("HitOther", KnownModIndex:GetModActualName("FAtiMA-DST")) then self.inst:ListenForEvent("onhitother", function(inst, data) OnActionEndEvent("HitOther", data.target.GUID, self) end) end
+	
+	
+
+--	if GetModConfigData("HealthDelta", KnownModIndex:GetModActualName("FAtiMA-DST")) then self.inst:ListenForEvent("healthdelta", function(inst, data) Event("HealthDelta", data, self) end) end
+--	if GetModConfigData("PlayerDied", KnownModIndex:GetModActualName("FAtiMA-DST")) then self.inst:ListenForEvent("playerdied", function(inst, data) Event("PlayerDied", data.victim.GUID, self) end) end
+--	if GetModConfigData("AdvanceSeason", KnownModIndex:GetModActualName("FAtiMA-DST")) then self.inst:ListenForEvent("ms_advanceseason", function(inst, data) Event("AdvanceSeason", data.victim.GUID, self) end) end
+--	if GetModConfigData("Ignite", KnownModIndex:GetModActualName("FAtiMA-DST")) then self.inst:ListenForEvent("onignite", function(inst, data) Event("Ignite", data.victim.GUID, self) end) end
+--	if GetModConfigData("BuildStructure", KnownModIndex:GetModActualName("FAtiMA-DST")) then self.inst:ListenForEvent("buildstructure", function(inst, data) Event("BuildStructure", data.victim.GUID, self) end) end
+--	if GetModConfigData("BuildItem", KnownModIndex:GetModActualName("FAtiMA-DST")) then self.inst:ListenForEvent("builditem", function(inst, data) Event("BuildItem", data.victim.GUID, self) end) end
+--	if GetModConfigData("WeatherTick", KnownModIndex:GetModActualName("FAtiMA-DST")) then self.inst:ListenForEvent("weathertick", function(inst, data) Event("WeatherTick", data.victim.GUID, self) end) end
+--	if GetModConfigData("SeasonTick", KnownModIndex:GetModActualName("FAtiMA-DST")) then self.inst:ListenForEvent("seasontick", function(inst, data) Event("SeasonTick", data.victim.GUID, self) end) end
+--	if GetModConfigData("PrecipitationChanged", KnownModIndex:GetModActualName("FAtiMA-DST")) then self.inst:ListenForEvent("precipitationchanged", function(inst, data) Event("PrecipitationChanged", data.victim.GUID, self) end) end
+--	if GetModConfigData("PlayerActivated", KnownModIndex:GetModActualName("FAtiMA-DST")) then self.inst:ListenForEvent("playeractivated", function(inst, data) Event("PlayerActivated", data.victim.GUID, self) end) end
+--	if GetModConfigData("PlayerDeactivated", KnownModIndex:GetModActualName("FAtiMA-DST")) then self.inst:ListenForEvent("playerdeactivated", function(inst, data) Event("PlayerDeactivated", data.victim.GUID, self) end) end
+--	if GetModConfigData("PlayerJoined", KnownModIndex:GetModActualName("FAtiMA-DST")) then self.inst:ListenForEvent("ms_playerjoined", function(inst, data) Event("PlayerJoined", data.victim.GUID, self) end) end
+--	if GetModConfigData("PlayerLeft", KnownModIndex:GetModActualName("FAtiMA-DST")) then self.inst:ListenForEvent("ms_playerleft", function(inst, data) Event("PlayerLeft", data.victim.GUID, self) end) end
+	-- "killed", "onhitother", "attacked", "weathertick", "seasontick", "precipitationchanged", "death", "playeractivated", "playerdeactivated", "enterdark", "enterlight", "nightvision", "healthdelta", "ms_playerjoined", "ms_playerleft", "playerdied", "ms_advanceseason", "onignite", "buildstructure", "builditem"
 
     -----------------------
     -------- Brain --------

--- a/FAtiMA-Server/Perceptions.cs
+++ b/FAtiMA-Server/Perceptions.cs
@@ -132,26 +132,35 @@ namespace FAtiMA_Server
 
             foreach (Item i in Vision)
             {
-                bv = rpc.GetBeliefValue("InSight(" + i.GUID + ")");
-                if (bv == null || !bv.Equals("True"))
-                    rpc.Perceive(EventHelper.PropertyChange("InSight(" + i.GUID + ")", "True", rpc.CharacterName.ToString()));
-                i.UpdatePerception(rpc);
+                if(i != null)
+                {
+                    bv = rpc.GetBeliefValue("InSight(" + i.GUID + ")");
+                    if (bv == null || !bv.Equals("True"))
+                        rpc.Perceive(EventHelper.PropertyChange("InSight(" + i.GUID + ")", "True", rpc.CharacterName.ToString()));
+                    i.UpdatePerception(rpc);
+                }
             }
 
             foreach (Item i in ItemSlots)
             {
-                bv = rpc.GetBeliefValue("InInventory(" + i.GUID + ")");
-                if (bv == null || !bv.Equals("True"))
-                    rpc.Perceive(EventHelper.PropertyChange("InInventory(" + i.GUID + ")", "TRUE", rpc.CharacterName.ToString()));
-                i.UpdatePerception(rpc);
+                if (i != null)
+                {
+                    bv = rpc.GetBeliefValue("InInventory(" + i.GUID + ")");
+                    if (bv == null || !bv.Equals("True"))
+                        rpc.Perceive(EventHelper.PropertyChange("InInventory(" + i.GUID + ")", "TRUE", rpc.CharacterName.ToString()));
+                    i.UpdatePerception(rpc);
+                }
             }
 
             foreach (EquippedItems i in EquipSlots)
             {
-                bv = rpc.GetBeliefValue("IsEquipped(" + i.GUID + "," + i.Slot + ")");
-                if (bv == null || !bv.Equals("True"))
-                    rpc.Perceive(EventHelper.PropertyChange("IsEquipped(" + i.GUID + "," + i.Slot + ")", "TRUE", rpc.CharacterName.ToString()));
-                i.UpdatePerception(rpc);
+                if (i != null)
+                {
+                    bv = rpc.GetBeliefValue("IsEquipped(" + i.GUID + "," + i.Slot + ")");
+                    if (bv == null || !bv.Equals("True"))
+                        rpc.Perceive(EventHelper.PropertyChange("IsEquipped(" + i.GUID + "," + i.Slot + ")", "TRUE", rpc.CharacterName.ToString()));
+                    i.UpdatePerception(rpc);
+                }
             }
 
             rpc.Update();
@@ -210,17 +219,17 @@ namespace FAtiMA_Server
             s += "\n\tVision:\n";
             foreach (Item v in Vision)
             {
-                s += "\t\t" + v.ToString() + "\n";
+                if (v != null) s += "\t\t" + v.ToString() + "\n";
             }
             s += "\tItemSlots:\n";
             foreach (Item i in ItemSlots)
             {
-                s += "\t\t" + i.ToString() + "\n";
+                if (i != null) s += "\t\t" + i.ToString() + "\n";
             }
             s += "\tEquipSlots:\n";
             foreach (Item e in EquipSlots)
             {
-                s += "\t\t" + e.ToString() + "\n";
+                if (e != null) s += "\t\t" + e.ToString() + "\n";
             }
             return s;
         }

--- a/FAtiMA-Server/Perceptions.cs
+++ b/FAtiMA-Server/Perceptions.cs
@@ -25,8 +25,6 @@ namespace FAtiMA_Server
         public int PosY { get; set; }
         public int PosZ { get; set; }
 
-        //TODO: Add something to track which part of the day the agent is in.
-
         [JsonConstructor]
         public Perceptions(List<EquippedItems> equipslots, List<Item> vision, List<Item> itemslots,
             float hunger, float sanity, float health, float moisture, float temperature, bool isfreezing, bool isoverheating, bool isbusy, float posx, float posy, float posz)

--- a/FAtiMA-Server/Program.cs
+++ b/FAtiMA-Server/Program.cs
@@ -77,24 +77,30 @@ namespace FAtiMA_Server
                         Debug.WriteLine(t);
                         return JsonConvert.SerializeObject(action);
                     case "/events":
-                        //Console.Write("An event occured... ");
-                        //if (request.HasEntityBody)
-                        //{
-                        //    using (System.IO.Stream body = request.InputStream) // here we have data
-                        //    {
-                        //        using (System.IO.StreamReader reader = new System.IO.StreamReader(body, request.ContentEncoding))
-                        //        {
-                        //            string e = reader.ReadToEnd();
-                        //            var p = JsonConvert.DeserializeObject<Event>(e);
-                        //            Walter.Perceive(p.ToName());
-                        //            Console.Write(p.ToString());
-                        //            Console.WriteLine(" Done!");
-                        //            return JsonConvert.True;
-                        //        }
-                        //    }
-                        //}
-                        //Console.WriteLine("Event processed!");
-                        return JsonConvert.True;
+                        Console.Write("An event occured... ");
+                        if (request.HasEntityBody)
+                        {
+                            using (System.IO.Stream body = request.InputStream) // here we have data
+                            {
+                                using (System.IO.StreamReader reader = new System.IO.StreamReader(body, request.ContentEncoding))
+                                {
+                                    string s = reader.ReadToEnd();
+                                    var e = JsonConvert.DeserializeObject<Event>(s);
+                                    Console.WriteLine(e.ToString());
+                                    try
+                                    {
+                                        e.Perceive(Walter);
+                                    }
+                                    catch (Exception excpt)
+                                    {
+                                        Debug.WriteLine(e.ToString());
+                                        throw excpt;
+                                    }
+                                    return JsonConvert.True;
+                                }
+                            }
+                        }
+                        return JsonConvert.False;
                     default:
                         return JsonConvert.Null;
                 }

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository aims to provide an integration of FAtiMA-Toolkit with Don't Star
 - Although not a prerequisite, some knowledge of the game will be helpful.
 - DST modding is encouraged and completely accepted by the game developers, however, there is no documentation whatsoever. Luckily, every line of code is available in the game directory. I recommend the use of an editor that supports the *Search in files* functionality. You won't need to make any mod for the game, but you'll eventually need to search the game files to understand the actions and how everything works. Check the Understanding the Actions section.
 
-### Creating an agent
+## Creating an agent
 
 This integration has two components: **FAtiMA-Server** and **FAtiMA-DST**. The former is a C# console application that will run FAtiMA, and the latter is a mod for DST that will control the character. You can think of **FAtiMA-Server** has the brains of the agents and **FAtiMA-DST** has the body.
 
@@ -19,76 +19,75 @@ To create an agent you'll need to follow these general steps.
 3. Launch **FAtiMA-Server** console application.
 4. Launch a game with the **FAtiMA-DST** mod enabled.
 
-### Creating a RPC
+## Creating a RPC
 
 FAtiMA-Toolkit provides tools to create agents for any scenarios. For this particular scenario, there are some restrictions you'll need to understand before you can write your agent.
 
-#### Beliefs
+### Beliefs
 
 These represent the information the agent has available when making decisions. They will represent both the state of the agent and the state of the world. These beliefs will be used in the conditions for the actions you'll define.
 
 The values enclosed in square brackets represent variables.
 
-##### Agent's State
+#### Agent's State
 
 These beliefs represent the agent's state, what he is seeing, carrying and using.
 
-`Health([Name]) = [value]`
+|Belief|Description|
+|:---|:---|
+|`Health([name]) = [value]`|Describes the agent's (*name*) health|
+|`Hunger([name]) = [value]`|Describes the agent's (*name*) hunger|
+|`Sanity([name]) = [value]`|Describes the agent's (*name*) sanity|
+|`Moisture([name]) = [value]`|Describes the agent's (*name*) moisture level|
+|`Temperature([name]) = [value]`|Describes the agent's (*name*) temperature|
+|`IsFreezing([name]) = [bool]`|Describes if the agent (*name*) is taking damage from extreme cold|
+|`IsOverheating([name]) = [bool]`|Describes if the agent (*name*) is taking damage from extreme hot|
+|`IsBusy([name]) = [bool]`|Describes if the agent (*name*) is currently executing any action|
+|`PosX([name]) = [value]`|The agent's (*name*) current X position|
+|`PosZ([name]) = [value]`|The agent's (*name*) current Y position|
+|`InSight([GUID]) = [bool]`|What the agent (*name*) is currently seeing|
+|`InInventory([GUID]) = [bool]`|What the agent (*name*) has in his inventory|
+|`IsEquipped([GUID], [slot]) = [bool]`|What the agent (*name*) has equipped in which *slot*|
+|`Light([name]) = [value]`|Defines if the agent (*name*) is in the light or darkness. *value* can be 'light' or 'dark'|
 
-`Hunger([Name]) = [value]`
-
-`Sanity([Name]) = [value]`
-
-`Moisture([Name]) = [value]`
-
-`Temperature([Name]) = [value]`
-
-`IsFreezing([Name]) = [bool]`
-
-`IsOverheating([Name]) = [bool]`
-
-`IsBusy([Name]) = [bool]`
-
-`PosX([Name]) = [value]`
-
-`PosZ([Name]) = [value]`
-
-`InSight([GUID]) = [bool]`
-
-`InInventory([GUID]) = [bool]`
-
-`IsEquipped([GUID], [slot]) = [bool]`
-
-##### World's State
+#### World's State
 
 These beliefs represent information about the world and should be used in addiction to what the agent is seeing.
 
-`Entity([GUID], [prefab]) = [Quantity]`
+|Belief|Description|
+|:---|:---|
+|`Entity([GUID], [prefab]) = [quantity]`|Defines entities, what they are (*prefab*) and how big is the stack (*quantity*)|
+|`ChopWorkable([GUID]) = [bool]`|Defines if the given entity is workable by an axe|
+|`DigWorkable([GUID]) = [bool]`|Defines if the given entity is workable by a shovel|
+|`HammerWorkable([GUID]) = [bool]`|Defines if the given entity is workable by an hammer|
+|`MineWorkable([GUID]) = [bool]`|Defines if the given entity is workable by a pick|
+|`Pickable([GUID]) = [bool]`|Defines if the given entity is pickable (either from the ground or collectable)|
+|`PosX([GUID]) = [value]`|Defines the X coordinate (*value*) of an entity|
+|`PosZ([GUID]) = [value]`|Defines the Z coordinate (*value*) of an entity|
+|`Day(Phase) = [value]`|Defines the phase of the day. *value* can be 'day', 'dusk', and 'night'|
 
-`ChopWorkable([GUID]) = [bool]`
+### Events
 
-`DigWorkable([GUID]) = [bool]`
+In addition to the Beliefs, we also provide a way to listen to in-game events and register them in FAtiMA, e.g. whenever something is killed, DST does a 'killed' event which can be listened to and registered as a FAtiMA event by simply enabling it on the mod configurations (by default all event listening is turned off).
 
-`HammerWorkable([GUID]) = [bool]`
-
-`MineWorkable([GUID]) = [bool]`
-
-`Pickable([GUID]) = [bool]`
-
-`PosX([GUID]) = [value]`
-
-`PosZ([GUID]) = [value]`
+|Event|Description|
+|:----:|:---|
+|`Event(Action-End, [subject], Attacked, [target])`|Represents an attack made on the *target* by the *subject*|
+|`Event(Action-End, [subject], Killed, [target])`|Represents the killing of the *target* by the hand of the *subject*|
+|`Event(Action-End, [subject], Death, [target])`|Represents the death of the *subject* by the hand of the *target*|
+|`Event(Action-End, [subject], HitOther, [target])`|Represents attacks the *subject* made against the *target*|
+|`Event(Action-End, [subject], MissOther, [target])`|Represents attacks the *subject* missed against the *target*|
 
 
-#### Actions
+### Actions
 
 **It's imperative that all actions have the following structure**
 
 `Action([action], [invobject], [posx], [posz], [recipe]) = [target]`
 
-Even if an action those not requires a specific parameter you must specify it as *-*.
+Even if an action those not requires a specific parameter you must specify it as `-`.
 
-##### Understanding the Actions
+#### Understanding the Actions
 
 Whenever you want to better understand a specific action, you should look for it in the **actions.lua** script and see what it checks and does. Eventually you'll need to dig into the **components** folder and search in those scripts.
 


### PR DESCRIPTION
The agent can now listen to and register events from the game into FAtiMA.

Introduced two new beliefs to represent the state of the day ('day', 'dusk', and 'night') and if the agent is in the presence of light or not.